### PR TITLE
Add env string method

### DIFF
--- a/sys/environment.go
+++ b/sys/environment.go
@@ -15,6 +15,10 @@ const (
 	Dev     Environment = "dev"
 )
 
+func (e Environment) String() string {
+	return string(e)
+}
+
 func NewEnvironment(env string) (Environment, error) {
 	return parseEnvironment(env)
 }


### PR DESCRIPTION
Adds a helpful string method so i dont have to do `string(env)` everywhere like a scrub