### PR TITLE
nats: fix match fetch batch on pull, expose ack wait config

### DIFF
--- a/nats/ephemeral.go
+++ b/nats/ephemeral.go
@@ -150,7 +150,7 @@ func newEphemeralConsumerWithConfig(config ephemeralConsumerConfig) (Subscriber,
 			)
 		},
 		handler:        config.Handler,
-		maxfetch:       config.MaxDeliver,
+		maxfetch:       config.MaxRequestBatch,
 		extendInterval: config.AckWait,
 		disableLog:     config.DisableSubLogging,
 	})

--- a/nats/nats.go
+++ b/nats/nats.go
@@ -309,5 +309,8 @@ func diffConfig(a nats.ConsumerConfig, b nats.ConsumerConfig) (string, bool) {
 	if a.MaxRequestBatch != b.MaxRequestBatch {
 		return fmt.Sprintf("max_fetch: %v != %v", a.MaxRequestBatch, b.MaxRequestBatch), false
 	}
+	if a.AckWait != b.AckWait {
+		return fmt.Sprintf("ack_wait: %v != %v", a.AckWait, b.AckWait), false
+	}
 	return "", true
 }


### PR DESCRIPTION
The subscriber wasn't using the right value for fetch sub max.
Expose the ack max duration config