### PR TITLE
[RBR-1571]: all for log-level to be set via env var when logger is instantiated

### DIFF
--- a/logger/console.go
+++ b/logger/console.go
@@ -204,5 +204,7 @@ func NewConsoleLogger(levels ...LogLevel) SinkLogger {
 	if len(levels) > 0 {
 		return (&consoleLogger{logLevel: levels[0], sinkLogLevel: LevelNone}).Clone(nil, nil)
 	}
-	return (&consoleLogger{logLevel: LevelDebug, sinkLogLevel: LevelNone}).Clone(nil, nil)
+	level := GetLevelFromEnv()
+
+	return (&consoleLogger{logLevel: level, sinkLogLevel: LevelNone}).Clone(nil, nil)
 }

--- a/logger/console_test.go
+++ b/logger/console_test.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"bytes"
 	"log"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,6 +68,61 @@ func TestConsoleLogger(t *testing.T) {
 		for _, shouldNotContain := range tt.shouldNotContain {
 			assert.NotContains(t, output, shouldNotContain)
 		}
+	}
+}
+
+func TestConsoleLoggerWithEnvLevel(t *testing.T) {
+
+	tests := []struct {
+		level            string
+		shouldContain    []string
+		shouldNotContain []string
+	}{
+		{
+			level:            "TRACE",
+			shouldContain:    []string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"},
+			shouldNotContain: []string{},
+		},
+		{
+			level:            "DEBUG",
+			shouldContain:    []string{"DEBUG", "INFO", "WARN", "ERROR"},
+			shouldNotContain: []string{"TRACE"},
+		},
+		{
+			level:            "INFO",
+			shouldContain:    []string{"INFO", "WARN", "ERROR"},
+			shouldNotContain: []string{"TRACE", "DEBUG"},
+		},
+		{
+			level:            "WARN",
+			shouldContain:    []string{"WARN", "ERROR"},
+			shouldNotContain: []string{"TRACE", "DEBUG", "INFO"},
+		},
+		{
+			level:            "ERROR",
+			shouldContain:    []string{"ERROR"},
+			shouldNotContain: []string{"TRACE", "DEBUG", "INFO", "WARN"},
+		},
+	}
+
+	for _, tt := range tests {
+		os.Setenv("SM_LOG_LEVEL", tt.level)
+		logger := NewConsoleLogger().(*consoleLogger)
+
+		output := captureOutput(func() {
+			logger.Trace("This is a trace message")
+			logger.Debug("This is a debug message")
+			logger.Info("This is an info message")
+			logger.Warn("This is a warn message")
+			logger.Error("This is an error message")
+		})
+		for _, shouldContain := range tt.shouldContain {
+			assert.Contains(t, output, shouldContain)
+		}
+		for _, shouldNotContain := range tt.shouldNotContain {
+			assert.NotContains(t, output, shouldNotContain)
+		}
+		os.Unsetenv("SM_LOG_LEVEL")
 	}
 }
 

--- a/logger/init.go
+++ b/logger/init.go
@@ -2,7 +2,9 @@ package logger
 
 import (
 	"io"
+	"os"
 	"regexp"
+	"strings"
 )
 
 // LogLevel defines the level of logging
@@ -16,6 +18,25 @@ const (
 	LevelError
 	LevelNone
 )
+
+// GetLevelFrom env will look at the environment var `SM_LOG_LEVEL` and convert it into the appropriate LogLevel
+func GetLevelFromEnv() LogLevel {
+	s := os.Getenv("SM_LOG_LEVEL")
+	switch strings.ToLower(s) { // Convert the string to lowercase to make it case-insensitive
+	case "trace":
+		return LevelTrace
+	case "debug":
+		return LevelDebug
+	case "info":
+		return LevelInfo
+	case "warn":
+		return LevelWarn
+	case "error":
+		return LevelError
+	default:
+		return LevelDebug // Return an unknown or default value for invalid strings
+	}
+}
 
 type Sink io.Writer
 

--- a/logger/json.go
+++ b/logger/json.go
@@ -178,7 +178,8 @@ func NewJSONLogger(levels ...LogLevel) Logger {
 	if len(levels) > 0 {
 		return &jsonLogger{logLevel: levels[0]}
 	}
-	return &jsonLogger{logLevel: LevelDebug}
+	level := GetLevelFromEnv()
+	return &jsonLogger{logLevel: level}
 
 }
 


### PR DESCRIPTION
This keeps the existing behaviors and adds a new one if no level is passed in when creating a logger. This will make it easier to tune deployed programs.