### PR TITLE
LOTUS-6533 - allow local docker address via dns lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+.idea/

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -97,6 +97,19 @@ func (d *Dns) Lookup(ctx context.Context, hostname string) (bool, *net.IP, error
 	if (hostname == "localhost" || hostname == "127.0.0.1") && d.isLocal {
 		return true, &net.IP{127, 0, 0, 1}, nil
 	}
+	// Support host.docker.internal for Docker environments (host machine gateway)
+	// In Docker, this resolves via /etc/hosts set by extra_hosts or natively on Mac/Windows
+	if hostname == "host.docker.internal" && d.isLocal {
+		// Use system resolver for this special hostname
+		ips, err := net.DefaultResolver.LookupIP(ctx, "ip4", hostname)
+		if err != nil {
+			return false, nil, fmt.Errorf("failed to resolve host.docker.internal: %w", err)
+		}
+		if len(ips) == 0 {
+			return false, nil, fmt.Errorf("no IP addresses found for host.docker.internal")
+		}
+		return true, &ips[0], nil
+	}
 	if isPrivateIP(hostname) && !d.isLocal {
 		return false, nil, ErrInvalidIP
 	}

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -97,10 +97,7 @@ func (d *Dns) Lookup(ctx context.Context, hostname string) (bool, *net.IP, error
 	if (hostname == "localhost" || hostname == "127.0.0.1") && d.isLocal {
 		return true, &net.IP{127, 0, 0, 1}, nil
 	}
-	// Support host.docker.internal for Docker environments (host machine gateway)
-	// In Docker, this resolves via /etc/hosts set by extra_hosts or natively on Mac/Windows
 	if hostname == "host.docker.internal" && d.isLocal {
-		// Use system resolver for this special hostname
 		ips, err := net.DefaultResolver.LookupIP(ctx, "ip4", hostname)
 		if err != nil {
 			return false, nil, fmt.Errorf("failed to resolve host.docker.internal: %w", err)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds local-mode support to resolve `host.docker.internal` via IPv4 in `Dns.Lookup`.
> 
> - **DNS**:
>   - `dns/dns.go`: Enhance `Dns.Lookup` to handle `host.docker.internal` when `isLocal` is true by performing an IPv4 lookup via `net.DefaultResolver` and returning the first IP with proper error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48e76b5c44344330729d76daa0b9b0cfcb67ce3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->