### PR TITLE
[RBR-3350]: Add zap-backed logger implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	github.com/vmihailenco/msgpack/v5 v5.4.1
+	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/zap v1.28.0
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sync v0.20.0
 	google.golang.org/api v0.204.0
@@ -58,7 +60,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,14 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.28.0 h1:IZzaP1Fv73/T/pBMLk4VutPl36uNC+OSUh3JLG3FIjo=
+go.uber.org/zap v1.28.0/go.mod h1:rDLpOi171uODNm/mxFcuYWxDsqWSAVkFdX4XojSKg/Q=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/logger/console.go
+++ b/logger/console.go
@@ -195,6 +195,8 @@ func (c *consoleLogger) Fatal(msg string, args ...interface{}) {
 	os.Exit(1)
 }
 
+func (c *consoleLogger) Flush() error { return nil }
+
 func (c *consoleLogger) SetLogLevel(level LogLevel) {
 	c.logLevel = level
 }

--- a/logger/context.go
+++ b/logger/context.go
@@ -1,0 +1,24 @@
+package logger
+
+import "context"
+
+type contextKey struct{}
+
+// ToContext stores a Logger in the context.
+func ToContext(ctx context.Context, log Logger) context.Context {
+	return context.WithValue(ctx, contextKey{}, log)
+}
+
+// FromContext retrieves a Logger from the context.
+// If the logger supports GCP trace correlation (zapLogger), it automatically
+// enriches the returned logger with OTEL span/trace IDs from the context.
+// Returns a default production Zap logger if none is stored in the context.
+func FromContext(ctx context.Context) Logger {
+	if log, ok := ctx.Value(contextKey{}).(Logger); ok {
+		if zl, ok := log.(*zapLogger); ok && zl.gcpTraceCorrelation {
+			return zl.WithContext(ctx)
+		}
+		return log
+	}
+	return NewZapLogger()
+}

--- a/logger/init.go
+++ b/logger/init.go
@@ -60,6 +60,9 @@ type Logger interface {
 	Error(msg string, args ...interface{})
 	// Fatal level logging and exit with code 1
 	Fatal(msg string, args ...interface{})
+	// Flush flushes any buffered log entries. Call before process exit.
+	// Implementations that don't buffer (console, JSON) return nil.
+	Flush() error
 }
 
 type SinkLogger interface {

--- a/logger/json.go
+++ b/logger/json.go
@@ -169,6 +169,8 @@ func (c *jsonLogger) Fatal(msg string, args ...interface{}) {
 	c.Log(LevelError, "ERROR", msg, args...)
 }
 
+func (c *jsonLogger) Flush() error { return nil }
+
 func (c *jsonLogger) SetLogLevel(level LogLevel) {
 	c.logLevel = level
 }

--- a/logger/multi.go
+++ b/logger/multi.go
@@ -44,6 +44,16 @@ func (m *muxLogger) Fatal(msg string, args ...interface{}) {
 	m.each(func(l Logger) { l.Fatal(msg, args...) })
 }
 
+func (m *muxLogger) Flush() error {
+	var err error
+	for _, l := range m.loggers {
+		if e := l.Flush(); e != nil {
+			err = e
+		}
+	}
+	return err
+}
+
 func (m *muxLogger) each(f func(Logger)) {
 	for _, l := range m.loggers {
 		f(l)

--- a/logger/test.go
+++ b/logger/test.go
@@ -67,6 +67,8 @@ func (c *TestLogger) Fatal(msg string, args ...interface{}) {
 	os.Exit(1)
 }
 
+func (c *TestLogger) Flush() error { return nil }
+
 // NewTestLogger returns a new Logger instance useful for testing
 func NewTestLogger() *TestLogger {
 	return &TestLogger{

--- a/logger/zap.go
+++ b/logger/zap.go
@@ -1,0 +1,129 @@
+package logger
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var zapLevels = map[LogLevel]zapcore.Level{
+	LevelTrace: zapcore.DebugLevel,
+	LevelDebug: zapcore.DebugLevel,
+	LevelInfo:  zapcore.InfoLevel,
+	LevelWarn:  zapcore.WarnLevel,
+	LevelError: zapcore.ErrorLevel,
+	LevelNone:  zapcore.FatalLevel,
+}
+
+func toZapLevel(level LogLevel) zap.AtomicLevel {
+	if zl, ok := zapLevels[level]; ok {
+		return zap.NewAtomicLevelAt(zl)
+	}
+	return zap.NewAtomicLevelAt(zapcore.InfoLevel)
+}
+
+// ZapOption configures the Zap logger.
+type ZapOption func(*zapConfig)
+
+type zapConfig struct {
+	level               LogLevel
+	fields              map[string]interface{}
+	gcpTraceCorrelation bool
+}
+
+// WithLevel sets the minimum log level. Default is read from SM_LOG_LEVEL env var.
+func WithLevel(level LogLevel) ZapOption {
+	return func(c *zapConfig) { c.level = level }
+}
+
+// WithFields adds base fields to every log entry (e.g. service name, commit, pod).
+func WithFields(fields map[string]interface{}) ZapOption {
+	return func(c *zapConfig) { c.fields = fields }
+}
+
+// WithGCPTraceCorrelation enables automatic injection of OTEL span/trace IDs
+// into log entries when retrieved via FromContext().
+func WithGCPTraceCorrelation() ZapOption {
+	return func(c *zapConfig) { c.gcpTraceCorrelation = true }
+}
+
+// zapLogger implements Logger backed by zap.SugaredLogger.
+type zapLogger struct {
+	log                 *zap.SugaredLogger
+	gcpTraceCorrelation bool
+}
+
+var _ Logger = (*zapLogger)(nil)
+
+// NewZapLogger creates a Logger backed by zap with production defaults.
+func NewZapLogger(opts ...ZapOption) Logger {
+	cfg := &zapConfig{level: GetLevelFromEnv()}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	zapCfg := zap.NewProductionConfig()
+	zapCfg.Level = toZapLevel(cfg.level)
+
+	if len(cfg.fields) > 0 {
+		zapCfg.InitialFields = cfg.fields
+	}
+
+	l, err := zapCfg.Build()
+	if err != nil {
+		panic(err)
+	}
+
+	return &zapLogger{
+		log:                 l.Sugar(),
+		gcpTraceCorrelation: cfg.gcpTraceCorrelation,
+	}
+}
+
+func (z *zapLogger) With(metadata map[string]interface{}) Logger {
+	fields := make([]interface{}, 0, len(metadata)*2)
+	for k, v := range metadata {
+		fields = append(fields, k, v)
+	}
+	return &zapLogger{
+		log:                 z.log.With(fields...),
+		gcpTraceCorrelation: z.gcpTraceCorrelation,
+	}
+}
+
+func (z *zapLogger) WithPrefix(prefix string) Logger {
+	return &zapLogger{
+		log:                 z.log.Named(prefix),
+		gcpTraceCorrelation: z.gcpTraceCorrelation,
+	}
+}
+
+func (z *zapLogger) Trace(msg string, args ...interface{}) { z.log.Debugf(msg, args...) }
+func (z *zapLogger) Debug(msg string, args ...interface{}) { z.log.Debugf(msg, args...) }
+func (z *zapLogger) Info(msg string, args ...interface{})  { z.log.Infof(msg, args...) }
+func (z *zapLogger) Warn(msg string, args ...interface{})  { z.log.Warnf(msg, args...) }
+func (z *zapLogger) Error(msg string, args ...interface{}) { z.log.Errorf(msg, args...) }
+func (z *zapLogger) Fatal(msg string, args ...interface{}) { z.log.Fatalf(msg, args...) }
+
+func (z *zapLogger) Flush() error { return z.log.Sync() }
+
+// WithContext returns a new logger enriched with OTEL trace/span IDs from the context.
+func (z *zapLogger) WithContext(ctx context.Context) Logger {
+	if !z.gcpTraceCorrelation {
+		return z
+	}
+	spanCtx := trace.SpanFromContext(ctx).SpanContext()
+	if !spanCtx.IsValid() {
+		return z
+	}
+	return &zapLogger{
+		log: z.log.With(
+			"logging.googleapis.com/spanId", spanCtx.SpanID().String(),
+			"logging.googleapis.com/trace", spanCtx.TraceID().String(),
+			"logging.googleapis.com/trace_sampled", spanCtx.IsSampled(),
+		),
+		gcpTraceCorrelation: z.gcpTraceCorrelation,
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `Logger` interface (adding `Flush()`), requiring all implementations/callers to compile and potentially altering shutdown behavior when `Sync()` is invoked on zap.
> 
> **Overview**
> Adds a new zap-backed `Logger` (`NewZapLogger`) with options for level/initial fields and *optional* OTEL-based GCP trace correlation (injecting `logging.googleapis.com/*` fields).
> 
> Extends the `Logger` interface with `Flush()` and wires it through existing loggers (`console`, `json`, `TestLogger`, and `NewMultiLogger`) so buffered implementations can be drained on shutdown.
> 
> Introduces context helpers (`ToContext`/`FromContext`) to store/retrieve loggers and automatically enrich zap loggers with span/trace IDs when enabled, and updates module deps to include `go.uber.org/zap` and `otel/trace` as direct requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad69425cd2550f037792320bea3dbf45846367be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->