### PR TITLE
[RBR-3350]: Add zap-backed logger implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	github.com/vmihailenco/msgpack/v5 v5.4.1
+	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sync v0.20.0
@@ -59,7 +60,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.52.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	github.com/vmihailenco/msgpack/v5 v5.4.1
+	go.uber.org/zap v1.28.0
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sync v0.20.0
 	google.golang.org/api v0.204.0
@@ -59,6 +60,7 @@ require (
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,14 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.28.0 h1:IZzaP1Fv73/T/pBMLk4VutPl36uNC+OSUh3JLG3FIjo=
+go.uber.org/zap v1.28.0/go.mod h1:rDLpOi171uODNm/mxFcuYWxDsqWSAVkFdX4XojSKg/Q=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/logger/README.md
+++ b/logger/README.md
@@ -58,6 +58,19 @@ log := logger.NewZapGCloudLogger()
 log := logger.NewZapLogger(logger.WithGCPTraceCorrelation())
 ```
 
+#### Sampling
+
+Zap enables sampling by default to protect against log flooding. Sampling is per-second, per-message (same level + message text):
+
+- **Initial: 100** — the first 100 entries are always logged
+- **Thereafter: 100** — after the initial 100, every 100th entry is logged; the rest are dropped
+
+This means a single log line must fire >100 times per second before any entries are dropped. To disable sampling:
+
+```go
+log := logger.NewZapLogger(logger.WithSampling(nil))
+```
+
 ### Console Logger
 
 Colorized terminal output for local development. Supports sinks for writing logs to an additional `io.Writer`.

--- a/logger/README.md
+++ b/logger/README.md
@@ -1,0 +1,151 @@
+# logger
+
+A structured logging package with multiple backend implementations, context propagation, and GCP Cloud Logging support.
+
+## Logger Interface
+
+All implementations satisfy the `Logger` interface:
+
+```go
+type Logger interface {
+    With(metadata map[string]interface{}) Logger
+    WithFields(args ...interface{}) Logger
+    WithPrefix(prefix string) Logger
+    WithContext(ctx context.Context) Logger
+    Trace(msg string, args ...interface{})
+    Debug(msg string, args ...interface{})
+    Info(msg string, args ...interface{})
+    Warn(msg string, args ...interface{})
+    Error(msg string, args ...interface{})
+    Fatal(msg string, args ...interface{})
+    Flush() error
+}
+```
+
+## Log Levels
+
+Six levels, controlled via the `SM_LOG_LEVEL` environment variable (case-insensitive, defaults to `debug`):
+
+`trace` | `debug` | `info` | `warn` | `error` | `none`
+
+```go
+level := logger.ParseLogLevel("info")
+level := logger.GetLevelFromEnv() // reads SM_LOG_LEVEL
+```
+
+## Implementations
+
+### Zap Logger (recommended)
+
+High-performance structured logger built on [uber-go/zap](https://github.com/uber-go/zap). Produces JSON output suitable for production and Cloud Logging.
+
+```go
+// Default — reads SM_LOG_LEVEL from env
+log := logger.NewZapLogger()
+
+// With explicit level
+log := logger.NewZapLogger(logger.WithLevel(logger.LevelInfo))
+
+// With initial fields
+log := logger.NewZapLogger(logger.WithFields(map[string]interface{}{
+    "service": "api",
+    "version": "1.2.0",
+}))
+
+// GCP Cloud Logging with trace correlation
+log := logger.NewZapGCloudLogger()
+// or manually:
+log := logger.NewZapLogger(logger.WithGCPTraceCorrelation())
+```
+
+### Console Logger
+
+Colorized terminal output for local development. Supports sinks for writing logs to an additional `io.Writer`.
+
+```go
+log := logger.NewConsoleLogger()                    // level from SM_LOG_LEVEL
+log := logger.NewConsoleLogger(logger.LevelTrace)   // explicit level
+
+// Attach a sink (e.g. file)
+sinkLog := logger.NewConsoleLogger()
+sinkLog.SetSink(file, logger.LevelDebug)
+```
+
+### JSON Logger
+
+Structured JSON output compatible with GCP Cloud Logging format.
+
+```go
+log := logger.NewJSONLogger()
+log := logger.NewGCloudLogger()                     // alias for NewJSONLogger
+log := logger.NewJSONLoggerWithSink(sink, logger.LevelInfo) // sink-only, no console
+```
+
+### Multi Logger
+
+Fan-out to multiple loggers simultaneously.
+
+```go
+log := logger.NewMultiLogger(
+    logger.NewConsoleLogger(),
+    logger.NewZapLogger(),
+)
+```
+
+### Test Logger
+
+Captures log entries in memory for assertions in tests.
+
+```go
+log := logger.NewTestLogger()
+log.Info("hello %s", "world")
+
+entry := log.Logs[0]
+// entry.Severity == "INFO"
+// entry.Message  == "hello %s"
+```
+
+## Enriching Logs
+
+```go
+// Structured metadata (map)
+log = log.With(map[string]interface{}{"requestID": "abc-123"})
+
+// Key-value pairs (variadic)
+log = log.WithFields("user", "alice", "action", "login")
+
+// Named prefix (shows as component/named logger)
+log = log.WithPrefix("auth")
+```
+
+## Context Integration
+
+Store and retrieve loggers from `context.Context`. `FromContext` automatically enriches logs with OpenTelemetry trace/span IDs when GCP trace correlation is enabled.
+
+```go
+// Store logger in context
+ctx = logger.ToContext(ctx, log)
+
+// Retrieve (returns default zap logger if none stored)
+log := logger.FromContext(ctx)
+
+// Manual trace enrichment
+log = log.WithContext(ctx) // adds trace_id, span_id, trace_sampled for GCP
+```
+
+## Flushing
+
+Call `Flush()` before application exit to ensure buffered entries are written (important for the zap logger).
+
+```go
+defer log.Flush()
+```
+
+## Utilities
+
+`KV` converts variadic key-value pairs into a `map[string]interface{}`:
+
+```go
+m := logger.KV("key1", "val1", "key2", 42)
+// map[string]interface{}{"key1": "val1", "key2": 42}
+```

--- a/logger/README.md
+++ b/logger/README.md
@@ -24,9 +24,11 @@ type Logger interface {
 
 ## Log Levels
 
-Six levels, controlled via the `SM_LOG_LEVEL` environment variable (case-insensitive, defaults to `debug`):
+Eight levels, controlled via the `SM_LOG_LEVEL` environment variable (case-insensitive, defaults to `debug`):
 
-`trace` | `debug` | `info` | `warn` | `error` | `none`
+`trace` | `debug` | `info` | `warn` | `error` | `panic` | `fatal` | `none`
+
+> **Note:** The zap logger defaults to `info` when `SM_LOG_LEVEL` is not set (see [Zap Logger](#zap-logger-recommended) below). Other implementations default to `debug`.
 
 ```go
 level := logger.ParseLogLevel("info")
@@ -40,11 +42,11 @@ level := logger.GetLevelFromEnv() // reads SM_LOG_LEVEL
 High-performance structured logger built on [uber-go/zap](https://github.com/uber-go/zap). Produces JSON output suitable for production and Cloud Logging.
 
 ```go
-// Default — reads SM_LOG_LEVEL from env
+// Default — Info level, GCP trace correlation enabled
 log := logger.NewZapLogger()
 
 // With explicit level
-log := logger.NewZapLogger(logger.WithLevel(logger.LevelInfo))
+log := logger.NewZapLogger(logger.WithLevel(logger.LevelDebug))
 
 // With initial fields
 log := logger.NewZapLogger(logger.WithFields(map[string]interface{}{
@@ -52,11 +54,33 @@ log := logger.NewZapLogger(logger.WithFields(map[string]interface{}{
     "version": "1.2.0",
 }))
 
-// GCP Cloud Logging with trace correlation
-log := logger.NewZapGCloudLogger()
-// or manually:
-log := logger.NewZapLogger(logger.WithGCPTraceCorrelation())
+// Disable GCP trace correlation
+log := logger.NewZapLogger(logger.WithGCPTraceCorrelation(false))
 ```
+
+#### Default Log Level
+
+The zap logger defaults to **Info** when no level is specified and `SM_LOG_LEVEL` is not set. This differs from other implementations which default to Debug. The priority is:
+
+1. `WithLevel(...)` option — highest priority
+2. `SM_LOG_LEVEL` environment variable
+3. **Info** — fallback default
+
+#### GCP Trace Correlation
+
+GCP trace correlation is **enabled by default**. When enabled, `WithContext(ctx)` and `FromContext(ctx)` automatically enrich log entries with OpenTelemetry trace/span IDs as GCP-compatible fields:
+
+- `logging.googleapis.com/trace`
+- `logging.googleapis.com/spanId`
+- `logging.googleapis.com/trace_sampled`
+
+This allows Cloud Logging to correlate log entries with distributed traces. To disable:
+
+```go
+log := logger.NewZapLogger(logger.WithGCPTraceCorrelation(false))
+```
+
+`NewZapGCloudLogger()` is an alias for `NewZapLogger()` — both behave identically.
 
 #### Sampling
 
@@ -133,17 +157,18 @@ log = log.WithPrefix("auth")
 
 ## Context Integration
 
-Store and retrieve loggers from `context.Context`. `FromContext` automatically enriches logs with OpenTelemetry trace/span IDs when GCP trace correlation is enabled.
+Store and retrieve loggers from `context.Context`. `FromContext` automatically enriches logs with OpenTelemetry trace/span IDs (since GCP trace correlation is enabled by default).
 
 ```go
 // Store logger in context
 ctx = logger.ToContext(ctx, log)
 
 // Retrieve (returns default zap logger if none stored)
+// Automatically adds trace/span IDs from context
 log := logger.FromContext(ctx)
 
-// Manual trace enrichment
-log = log.WithContext(ctx) // adds trace_id, span_id, trace_sampled for GCP
+// Manual trace enrichment (same as what FromContext does)
+log = log.WithContext(ctx)
 ```
 
 ## Flushing

--- a/logger/console.go
+++ b/logger/console.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -193,6 +194,12 @@ func (c *consoleLogger) Error(msg string, args ...interface{}) {
 func (c *consoleLogger) Fatal(msg string, args ...interface{}) {
 	c.Log(LevelError, c.errorLevelColor, c.errorMessageColor, "ERROR", msg, args...)
 	os.Exit(1)
+}
+
+func (c *consoleLogger) Flush() error { return nil }
+
+func (c *consoleLogger) WithContext(_ context.Context) Logger {
+	return c
 }
 
 func (c *consoleLogger) SetLogLevel(level LogLevel) {

--- a/logger/console.go
+++ b/logger/console.go
@@ -200,7 +200,9 @@ func (c *consoleLogger) Fatal(msg string, args ...interface{}) {
 	os.Exit(1)
 }
 
-func (c *consoleLogger) Flush() error { return nil }
+func (c *consoleLogger) Flush() error {
+	return nil
+}
 
 func (c *consoleLogger) WithContext(_ context.Context) Logger {
 	return c

--- a/logger/console.go
+++ b/logger/console.go
@@ -117,6 +117,10 @@ func (c *consoleLogger) SetSink(sink Sink, level LogLevel) {
 	c.sinkLogLevel = level
 }
 
+func (c *consoleLogger) WithFields(args ...interface{}) Logger {
+	return c.With(KV(args...))
+}
+
 func (c *consoleLogger) With(metadata map[string]interface{}) Logger {
 	kv := metadata
 	if c.metadata != nil {

--- a/logger/context.go
+++ b/logger/context.go
@@ -19,7 +19,6 @@ func getDefaultLogger() Logger {
 	return defaultLogger
 }
 
-// ToContext stores a Logger in the context.
 func ToContext(ctx context.Context, l Logger) context.Context {
 	return context.WithValue(ctx, contextKey{}, l)
 }

--- a/logger/context.go
+++ b/logger/context.go
@@ -1,0 +1,21 @@
+package logger
+
+import "context"
+
+type contextKey struct{}
+
+func ToContext(ctx context.Context, l Logger) context.Context {
+	return context.WithValue(ctx, contextKey{}, l)
+}
+
+func FromContext(ctx context.Context) (Logger, bool) {
+	l, ok := ctx.Value(contextKey{}).(Logger)
+	return l, ok
+}
+
+func FromContextOrDefault(ctx context.Context, fallback Logger) Logger {
+	if l, ok := FromContext(ctx); ok {
+		return l
+	}
+	return fallback
+}

--- a/logger/context.go
+++ b/logger/context.go
@@ -1,21 +1,36 @@
 package logger
 
-import "context"
+import (
+	"context"
+	"sync"
+)
 
 type contextKey struct{}
 
+var (
+	defaultLogger     Logger
+	defaultLoggerOnce sync.Once
+)
+
+func getDefaultLogger() Logger {
+	defaultLoggerOnce.Do(func() {
+		defaultLogger = NewZapLogger()
+	})
+	return defaultLogger
+}
+
+// ToContext stores a Logger in the context.
 func ToContext(ctx context.Context, l Logger) context.Context {
 	return context.WithValue(ctx, contextKey{}, l)
 }
 
-func FromContext(ctx context.Context) (Logger, bool) {
+// FromContext retrieves a Logger from the context and automatically
+// enriches it with OTEL trace fields (if the logger supports it).
+// Returns a default zap logger if none is stored.
+func FromContext(ctx context.Context) Logger {
 	l, ok := ctx.Value(contextKey{}).(Logger)
-	return l, ok
-}
-
-func FromContextOrDefault(ctx context.Context, fallback Logger) Logger {
-	if l, ok := FromContext(ctx); ok {
-		return l
+	if !ok {
+		l = getDefaultLogger()
 	}
-	return fallback
+	return l.WithContext(ctx)
 }

--- a/logger/context.go
+++ b/logger/context.go
@@ -23,9 +23,6 @@ func ToContext(ctx context.Context, l Logger) context.Context {
 	return context.WithValue(ctx, contextKey{}, l)
 }
 
-// FromContext retrieves a Logger from the context and automatically
-// enriches it with OTEL trace fields (if the logger supports it).
-// Returns a default zap logger if none is stored.
 func FromContext(ctx context.Context) Logger {
 	l, ok := ctx.Value(contextKey{}).(Logger)
 	if !ok {

--- a/logger/context_test.go
+++ b/logger/context_test.go
@@ -1,0 +1,52 @@
+package logger
+
+import (
+	"context"
+	"testing"
+)
+
+func TestToContextFromContext(t *testing.T) {
+	ctx := context.Background()
+	l := NewZapLogger(WithLevel(LevelInfo))
+
+	ctx = ToContext(ctx, l)
+	got, ok := FromContext(ctx)
+	if !ok {
+		t.Fatal("expected logger in context")
+	}
+	if got != l {
+		t.Fatal("expected same logger instance")
+	}
+}
+
+func TestFromContextEmpty(t *testing.T) {
+	ctx := context.Background()
+	got, ok := FromContext(ctx)
+	if ok {
+		t.Fatal("expected no logger in empty context")
+	}
+	if got != nil {
+		t.Fatal("expected nil logger from empty context")
+	}
+}
+
+func TestFromContextOrDefault(t *testing.T) {
+	fallback := NewZapLogger(WithLevel(LevelWarn))
+
+	t.Run("returns fallback when empty", func(t *testing.T) {
+		ctx := context.Background()
+		got := FromContextOrDefault(ctx, fallback)
+		if got != fallback {
+			t.Fatal("expected fallback logger")
+		}
+	})
+
+	t.Run("returns stored when present", func(t *testing.T) {
+		stored := NewZapLogger(WithLevel(LevelInfo))
+		ctx := ToContext(context.Background(), stored)
+		got := FromContextOrDefault(ctx, fallback)
+		if got != stored {
+			t.Fatal("expected stored logger, not fallback")
+		}
+	})
+}

--- a/logger/context_test.go
+++ b/logger/context_test.go
@@ -10,10 +10,7 @@ func TestToContextFromContext(t *testing.T) {
 	l := NewZapLogger(WithLevel(LevelInfo))
 
 	ctx = ToContext(ctx, l)
-	got, ok := FromContext(ctx)
-	if !ok {
-		t.Fatal("expected logger in context")
-	}
+	got := FromContext(ctx)
 	if got != l {
 		t.Fatal("expected same logger instance")
 	}
@@ -21,32 +18,8 @@ func TestToContextFromContext(t *testing.T) {
 
 func TestFromContextEmpty(t *testing.T) {
 	ctx := context.Background()
-	got, ok := FromContext(ctx)
-	if ok {
-		t.Fatal("expected no logger in empty context")
+	got := FromContext(ctx)
+	if got == nil {
+		t.Fatal("expected fallback logger, not nil")
 	}
-	if got != nil {
-		t.Fatal("expected nil logger from empty context")
-	}
-}
-
-func TestFromContextOrDefault(t *testing.T) {
-	fallback := NewZapLogger(WithLevel(LevelWarn))
-
-	t.Run("returns fallback when empty", func(t *testing.T) {
-		ctx := context.Background()
-		got := FromContextOrDefault(ctx, fallback)
-		if got != fallback {
-			t.Fatal("expected fallback logger")
-		}
-	})
-
-	t.Run("returns stored when present", func(t *testing.T) {
-		stored := NewZapLogger(WithLevel(LevelInfo))
-		ctx := ToContext(context.Background(), stored)
-		got := FromContextOrDefault(ctx, fallback)
-		if got != stored {
-			t.Fatal("expected stored logger, not fallback")
-		}
-	})
 }

--- a/logger/gcloud.go
+++ b/logger/gcloud.go
@@ -9,3 +9,8 @@ func NewGCloudLogger() Logger {
 func NewGCloudLoggerWithSink(sink Sink, level LogLevel) Logger {
 	return NewJSONLoggerWithSink(sink, level)
 }
+
+// NewZapGCloudLogger returns a new zap-based Logger for structured Google Cloud logging
+func NewZapGCloudLogger(opts ...ZapOption) Logger {
+	return NewZapLogger(opts...)
+}

--- a/logger/gcloud.go
+++ b/logger/gcloud.go
@@ -11,6 +11,7 @@ func NewGCloudLoggerWithSink(sink Sink, level LogLevel) Logger {
 }
 
 // NewZapGCloudLogger returns a new zap-based Logger for structured Google Cloud logging
+// with GCP trace correlation enabled by default.
 func NewZapGCloudLogger(opts ...ZapOption) Logger {
-	return NewZapLogger(opts...)
+	return NewZapLogger(append([]ZapOption{WithGCPTraceCorrelation()}, opts...)...)
 }

--- a/logger/gcloud.go
+++ b/logger/gcloud.go
@@ -13,5 +13,5 @@ func NewGCloudLoggerWithSink(sink Sink, level LogLevel) Logger {
 // NewZapGCloudLogger returns a new zap-based Logger for structured Google Cloud logging
 // with GCP trace correlation enabled by default.
 func NewZapGCloudLogger(opts ...ZapOption) Logger {
-	return NewZapLogger(append([]ZapOption{WithGCPTraceCorrelation()}, opts...)...)
+	return NewZapLogger(opts...)
 }

--- a/logger/init.go
+++ b/logger/init.go
@@ -17,6 +17,8 @@ const (
 	LevelInfo
 	LevelWarn
 	LevelError
+	LevelPanic
+	LevelFatal
 	LevelNone
 )
 
@@ -36,6 +38,10 @@ func ParseLogLevel(s string) LogLevel {
 		return LevelWarn
 	case "error":
 		return LevelError
+	case "panic":
+		return LevelPanic
+	case "fatal":
+		return LevelFatal
 	default:
 		return LevelDebug
 	}

--- a/logger/init.go
+++ b/logger/init.go
@@ -20,10 +20,10 @@ const (
 	LevelNone
 )
 
-// GetLevelFrom env will look at the environment var `SM_LOG_LEVEL` and convert it into the appropriate LogLevel
-func GetLevelFromEnv() LogLevel {
-	s := os.Getenv("SM_LOG_LEVEL")
-	switch strings.ToLower(s) { // Convert the string to lowercase to make it case-insensitive
+// ParseLogLevel converts a string to a LogLevel. Case-insensitive.
+// Returns LevelDebug for unrecognized values.
+func ParseLogLevel(s string) LogLevel {
+	switch strings.ToLower(s) {
 	case "none":
 		return LevelNone
 	case "trace":
@@ -37,8 +37,13 @@ func GetLevelFromEnv() LogLevel {
 	case "error":
 		return LevelError
 	default:
-		return LevelDebug // Return an unknown or default value for invalid strings
+		return LevelDebug
 	}
+}
+
+// GetLevelFromEnv reads the SM_LOG_LEVEL environment variable and converts it to a LogLevel.
+func GetLevelFromEnv() LogLevel {
+	return ParseLogLevel(os.Getenv("SM_LOG_LEVEL"))
 }
 
 type Sink io.Writer
@@ -47,6 +52,8 @@ type Sink io.Writer
 type Logger interface {
 	// With will return a new logger using metadata as the base context
 	With(metadata map[string]interface{}) Logger
+	// WithFields will return a new logger with the given key-value pairs as context
+	WithFields(args ...interface{}) Logger
 	// WithPrefix will return a new logger with a prefix prepended to the message
 	WithPrefix(prefix string) Logger
 	// WithContext returns a new logger enriched with context information (e.g., trace IDs)

--- a/logger/init.go
+++ b/logger/init.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"context"
 	"io"
 	"os"
 	"regexp"
@@ -48,6 +49,8 @@ type Logger interface {
 	With(metadata map[string]interface{}) Logger
 	// WithPrefix will return a new logger with a prefix prepended to the message
 	WithPrefix(prefix string) Logger
+	// WithContext returns a new logger enriched with context information (e.g., trace IDs)
+	WithContext(ctx context.Context) Logger
 	// Trace level logging
 	Trace(msg string, args ...interface{})
 	// Debug level logging
@@ -60,6 +63,8 @@ type Logger interface {
 	Error(msg string, args ...interface{})
 	// Fatal level logging and exit with code 1
 	Fatal(msg string, args ...interface{})
+	// Flush flushes any buffered log entries
+	Flush() error
 }
 
 type SinkLogger interface {

--- a/logger/json.go
+++ b/logger/json.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -171,6 +172,14 @@ func (c *jsonLogger) Fatal(msg string, args ...interface{}) {
 
 func (c *jsonLogger) SetLogLevel(level LogLevel) {
 	c.logLevel = level
+}
+
+func (c *jsonLogger) Flush() error {
+	return nil
+}
+
+func (c *jsonLogger) WithContext(_ context.Context) Logger {
+	return c
 }
 
 // NewJSONLogger returns a new Logger instance which can be used for structured logging

--- a/logger/json.go
+++ b/logger/json.go
@@ -67,6 +67,10 @@ func (c *jsonLogger) WithPrefix(prefix string) Logger {
 	return newlogger
 }
 
+func (c *jsonLogger) WithFields(args ...interface{}) Logger {
+	return c.With(KV(args...))
+}
+
 func (c *jsonLogger) With(metadata map[string]interface{}) Logger {
 	traceID := c.traceID
 	component := c.component

--- a/logger/multi.go
+++ b/logger/multi.go
@@ -9,6 +9,14 @@ type muxLogger struct {
 	loggers []Logger
 }
 
+func (m *muxLogger) WithFields(args ...interface{}) Logger {
+	var newLoggers []Logger
+	for _, l := range m.loggers {
+		newLoggers = append(newLoggers, l.WithFields(args...))
+	}
+	return NewMultiLogger(newLoggers...)
+}
+
 func (m *muxLogger) With(metadata map[string]interface{}) Logger {
 	var newLoggers []Logger
 	for _, l := range m.loggers {

--- a/logger/multi.go
+++ b/logger/multi.go
@@ -1,5 +1,10 @@
 package logger
 
+import (
+	"context"
+	"errors"
+)
+
 type muxLogger struct {
 	loggers []Logger
 }
@@ -42,6 +47,24 @@ func (m *muxLogger) Error(msg string, args ...interface{}) {
 
 func (m *muxLogger) Fatal(msg string, args ...interface{}) {
 	m.each(func(l Logger) { l.Fatal(msg, args...) })
+}
+
+func (m *muxLogger) Flush() error {
+	var errs []error
+	for _, l := range m.loggers {
+		if err := l.Flush(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (m *muxLogger) WithContext(ctx context.Context) Logger {
+	var newLoggers []Logger
+	for _, l := range m.loggers {
+		newLoggers = append(newLoggers, l.WithContext(ctx))
+	}
+	return NewMultiLogger(newLoggers...)
 }
 
 func (m *muxLogger) each(f func(Logger)) {

--- a/logger/test.go
+++ b/logger/test.go
@@ -1,6 +1,9 @@
 package logger
 
-import "os"
+import (
+	"context"
+	"os"
+)
 
 type TestLogEntry struct {
 	Severity  string
@@ -65,6 +68,14 @@ func (c *TestLogger) Error(msg string, args ...interface{}) {
 func (c *TestLogger) Fatal(msg string, args ...interface{}) {
 	c.Log("FATAL", msg, args...)
 	os.Exit(1)
+}
+
+func (c *TestLogger) Flush() error {
+	return nil
+}
+
+func (c *TestLogger) WithContext(_ context.Context) Logger {
+	return c
 }
 
 // NewTestLogger returns a new Logger instance useful for testing

--- a/logger/test.go
+++ b/logger/test.go
@@ -27,6 +27,10 @@ func (c *TestLogger) WithPrefix(prefix string) Logger {
 	return c
 }
 
+func (c *TestLogger) WithFields(args ...interface{}) Logger {
+	return c.With(KV(args...))
+}
+
 func (c *TestLogger) With(metadata map[string]interface{}) Logger {
 	kv := metadata
 	if c.metadata != nil {

--- a/logger/util.go
+++ b/logger/util.go
@@ -1,7 +1,5 @@
 package logger
 
-// KV converts variadic key-value pairs into a map[string]interface{}.
-// Keys must be strings; non-string keys and orphan keys are silently dropped.
 func KV(args ...interface{}) map[string]interface{} {
 	m := make(map[string]interface{}, len(args)/2)
 	for i := 0; i < len(args)-1; i += 2 {

--- a/logger/util.go
+++ b/logger/util.go
@@ -1,5 +1,13 @@
 package logger
 
-func WithKV(logger Logger, key string, value any) Logger {
-	return logger.With(map[string]interface{}{key: value})
+// KV converts variadic key-value pairs into a map[string]interface{}.
+// Keys must be strings; non-string keys and orphan keys are silently dropped.
+func KV(args ...interface{}) map[string]interface{} {
+	m := make(map[string]interface{}, len(args)/2)
+	for i := 0; i < len(args)-1; i += 2 {
+		if key, ok := args[i].(string); ok {
+			m[key] = args[i+1]
+		}
+	}
+	return m
 }

--- a/logger/zap.go
+++ b/logger/zap.go
@@ -58,7 +58,7 @@ func WithGCPTraceCorrelation() ZapOption {
 
 func NewZapLogger(opts ...ZapOption) Logger {
 	cfg := applyZapOptions(opts)
-	level := resolveLevel(cfg)
+	level := getLogLevel(cfg)
 	if level == LevelNone {
 		return nopZapLogger(cfg)
 	}
@@ -164,12 +164,11 @@ func applyZapOptions(opts []ZapOption) *zapConfig {
 	return cfg
 }
 
-func resolveLevel(cfg *zapConfig) LogLevel {
-	level := GetLevelFromEnv()
+func getLogLevel(cfg *zapConfig) LogLevel {
 	if cfg.levelSet {
-		level = cfg.level
+		return cfg.level
 	}
-	return level
+	return GetLevelFromEnv()
 }
 
 func mapLogLevelToZap(level LogLevel) zapcore.Level {
@@ -210,15 +209,15 @@ func nopZapLogger(cfg *zapConfig) *zapLogger {
 
 func newZapLoggerWithWriter(w io.Writer, opts ...ZapOption) *zapLogger {
 	cfg := applyZapOptions(opts)
-	level := resolveLevel(cfg)
-	if level == LevelNone {
+	logLevel := getLogLevel(cfg)
+	if logLevel == LevelNone {
 		return nopZapLogger(cfg)
 	}
 	encCfg := zap.NewProductionEncoderConfig()
 	encCfg.EncodeLevel = levelEncoder
 	ws := zapcore.AddSync(w)
 	encoder := zapcore.NewJSONEncoder(encCfg)
-	core := zapcore.NewCore(encoder, ws, mapLogLevelToZap(level))
+	core := zapcore.NewCore(encoder, ws, mapLogLevelToZap(logLevel))
 	base := zap.New(core, zap.WithFatalHook(zapcore.WriteThenNoop))
 	return buildZapLogger(base, cfg)
 }

--- a/logger/zap.go
+++ b/logger/zap.go
@@ -1,0 +1,214 @@
+package logger
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const zapTraceLevel = zapcore.DebugLevel - 1
+
+var zapLevels = map[LogLevel]zapcore.Level{
+	LevelTrace: zapTraceLevel,
+	LevelDebug: zapcore.DebugLevel,
+	LevelInfo:  zapcore.InfoLevel,
+	LevelWarn:  zapcore.WarnLevel,
+	LevelError: zapcore.ErrorLevel,
+}
+
+type ZapOption func(*zapConfig)
+
+type zapConfig struct {
+	level               LogLevel
+	levelSet            bool
+	fields              map[string]interface{}
+	gcpTraceCorrelation bool
+}
+
+type zapLogger struct {
+	sugar               *zap.SugaredLogger
+	gcpTraceCorrelation bool
+}
+
+var _ Logger = (*zapLogger)(nil)
+
+func WithLevel(level LogLevel) ZapOption {
+	return func(c *zapConfig) {
+		c.level = level
+		c.levelSet = true
+	}
+}
+
+func WithFields(fields map[string]interface{}) ZapOption {
+	return func(c *zapConfig) {
+		c.fields = fields
+	}
+}
+
+func WithGCPTraceCorrelation() ZapOption {
+	return func(c *zapConfig) {
+		c.gcpTraceCorrelation = true
+	}
+}
+
+func NewZapLogger(opts ...ZapOption) Logger {
+	cfg := applyZapOptions(opts)
+	level := resolveLevel(cfg)
+	if level == LevelNone {
+		return nopZapLogger(cfg)
+	}
+	zapCfg := zap.NewProductionConfig()
+	zapCfg.Level = zap.NewAtomicLevelAt(mapLogLevelToZap(level))
+	zapCfg.EncoderConfig.EncodeLevel = levelEncoder
+	base, _ := zapCfg.Build(zap.WithFatalHook(zapcore.WriteThenFatal))
+	return buildZapLogger(base, cfg)
+}
+
+func (z *zapLogger) Trace(msg string, args ...interface{}) {
+	z.sugar.Logf(zapTraceLevel, msg, args...)
+}
+
+func (z *zapLogger) Debug(msg string, args ...interface{}) {
+	z.sugar.Debugf(msg, args...)
+}
+
+func (z *zapLogger) Info(msg string, args ...interface{}) {
+	z.sugar.Infof(msg, args...)
+}
+
+func (z *zapLogger) Warn(msg string, args ...interface{}) {
+	z.sugar.Warnf(msg, args...)
+}
+
+func (z *zapLogger) Error(msg string, args ...interface{}) {
+	z.sugar.Errorf(msg, args...)
+}
+
+func (z *zapLogger) Fatal(msg string, args ...interface{}) {
+	z.sugar.Fatalf(msg, args...)
+}
+
+func (z *zapLogger) With(metadata map[string]interface{}) Logger {
+	if len(metadata) == 0 {
+		return z
+	}
+	fields := make([]interface{}, 0, len(metadata)*2)
+	for k, v := range metadata {
+		fields = append(fields, k, v)
+	}
+	return &zapLogger{
+		sugar:               z.sugar.With(fields...),
+		gcpTraceCorrelation: z.gcpTraceCorrelation,
+	}
+}
+
+func (z *zapLogger) WithPrefix(prefix string) Logger {
+	return &zapLogger{
+		sugar:               z.sugar.Named(prefix),
+		gcpTraceCorrelation: z.gcpTraceCorrelation,
+	}
+}
+
+func (z *zapLogger) WithContext(ctx context.Context) Logger {
+	if ctx == nil || !z.gcpTraceCorrelation {
+		return z
+	}
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		return z
+	}
+	return &zapLogger{
+		sugar: z.sugar.With(
+			zap.String("logging.googleapis.com/trace", sc.TraceID().String()),
+			zap.String("logging.googleapis.com/spanId", sc.SpanID().String()),
+			zap.Bool("logging.googleapis.com/trace_sampled", sc.IsSampled()),
+		),
+		gcpTraceCorrelation: z.gcpTraceCorrelation,
+	}
+}
+
+func (z *zapLogger) Flush() error {
+	err := z.sugar.Sync()
+	if err == nil {
+		return nil
+	}
+	// Ignore harmless PathError from syncing stdout/stderr — these can't be
+	// fsync'd on most OS/terminal combinations (known Zap issue on macOS/Linux).
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) {
+		return nil
+	}
+	return err
+}
+
+func applyZapOptions(opts []ZapOption) *zapConfig {
+	cfg := &zapConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}
+
+func resolveLevel(cfg *zapConfig) LogLevel {
+	level := GetLevelFromEnv()
+	if cfg.levelSet {
+		level = cfg.level
+	}
+	return level
+}
+
+func mapLogLevelToZap(level LogLevel) zapcore.Level {
+	if zl, ok := zapLevels[level]; ok {
+		return zl
+	}
+	return zapcore.DebugLevel
+}
+
+func levelEncoder(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
+	if l == zapTraceLevel {
+		enc.AppendString("trace")
+		return
+	}
+	zapcore.LowercaseLevelEncoder(l, enc)
+}
+
+func buildZapLogger(base *zap.Logger, cfg *zapConfig) *zapLogger {
+	if len(cfg.fields) > 0 {
+		fields := make([]zap.Field, 0, len(cfg.fields))
+		for k, v := range cfg.fields {
+			fields = append(fields, zap.Any(k, v))
+		}
+		base = base.With(fields...)
+	}
+	return &zapLogger{
+		sugar:               base.Sugar(),
+		gcpTraceCorrelation: cfg.gcpTraceCorrelation,
+	}
+}
+
+func nopZapLogger(cfg *zapConfig) *zapLogger {
+	return &zapLogger{
+		sugar:               zap.NewNop().Sugar(),
+		gcpTraceCorrelation: cfg.gcpTraceCorrelation,
+	}
+}
+
+func newZapLoggerWithWriter(w io.Writer, opts ...ZapOption) *zapLogger {
+	cfg := applyZapOptions(opts)
+	level := resolveLevel(cfg)
+	if level == LevelNone {
+		return nopZapLogger(cfg)
+	}
+	encCfg := zap.NewProductionEncoderConfig()
+	encCfg.EncodeLevel = levelEncoder
+	ws := zapcore.AddSync(w)
+	encoder := zapcore.NewJSONEncoder(encCfg)
+	core := zapcore.NewCore(encoder, ws, mapLogLevelToZap(level))
+	base := zap.New(core, zap.WithFatalHook(zapcore.WriteThenNoop))
+	return buildZapLogger(base, cfg)
+}

--- a/logger/zap.go
+++ b/logger/zap.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"os"
 
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -19,6 +20,8 @@ var zapLevels = map[LogLevel]zapcore.Level{
 	LevelInfo:  zapcore.InfoLevel,
 	LevelWarn:  zapcore.WarnLevel,
 	LevelError: zapcore.ErrorLevel,
+	LevelPanic: zapcore.PanicLevel,
+	LevelFatal: zapcore.FatalLevel,
 }
 
 type ZapOption func(*zapConfig)
@@ -50,9 +53,9 @@ func WithFields(fields map[string]interface{}) ZapOption {
 	}
 }
 
-func WithGCPTraceCorrelation() ZapOption {
+func WithGCPTraceCorrelation(enabled bool) ZapOption {
 	return func(c *zapConfig) {
-		c.gcpTraceCorrelation = true
+		c.gcpTraceCorrelation = enabled
 	}
 }
 
@@ -157,7 +160,7 @@ func (z *zapLogger) Flush() error {
 }
 
 func applyZapOptions(opts []ZapOption) *zapConfig {
-	cfg := &zapConfig{}
+	cfg := &zapConfig{gcpTraceCorrelation: true}
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -168,14 +171,17 @@ func getLogLevel(cfg *zapConfig) LogLevel {
 	if cfg.levelSet {
 		return cfg.level
 	}
-	return GetLevelFromEnv()
+	if _, ok := os.LookupEnv("SM_LOG_LEVEL"); ok {
+		return GetLevelFromEnv()
+	}
+	return LevelInfo
 }
 
 func mapLogLevelToZap(level LogLevel) zapcore.Level {
 	if zl, ok := zapLevels[level]; ok {
 		return zl
 	}
-	return zapcore.DebugLevel
+	return zapcore.InfoLevel
 }
 
 func levelEncoder(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
@@ -207,7 +213,7 @@ func nopZapLogger(cfg *zapConfig) *zapLogger {
 	}
 }
 
-func newZapLoggerWithWriter(w io.Writer, opts ...ZapOption) *zapLogger {
+func NewZapTestLogger(w io.Writer, opts ...ZapOption) *zapLogger {
 	cfg := applyZapOptions(opts)
 	logLevel := getLogLevel(cfg)
 	if logLevel == LevelNone {

--- a/logger/zap.go
+++ b/logger/zap.go
@@ -93,6 +93,16 @@ func (z *zapLogger) Fatal(msg string, args ...interface{}) {
 	z.sugar.Fatalf(msg, args...)
 }
 
+func (z *zapLogger) WithFields(args ...interface{}) Logger {
+	if len(args) == 0 {
+		return z
+	}
+	return &zapLogger{
+		sugar:               z.sugar.With(args...),
+		gcpTraceCorrelation: z.gcpTraceCorrelation,
+	}
+}
+
 func (z *zapLogger) With(metadata map[string]interface{}) Logger {
 	if len(metadata) == 0 {
 		return z

--- a/logger/zap_test.go
+++ b/logger/zap_test.go
@@ -23,7 +23,7 @@ type zapLogEntry struct {
 
 func newTestZapLogger(level LogLevel) (*zapLogger, *bytes.Buffer) {
 	var buf bytes.Buffer
-	logger := newZapLoggerWithWriter(&buf, WithLevel(level))
+	logger := NewZapTestLogger(&buf, WithLevel(level))
 	return logger, &buf
 }
 
@@ -147,7 +147,7 @@ func TestZapLoggerWithEnvLevel(t *testing.T) {
 	for _, tt := range tests {
 		os.Setenv("SM_LOG_LEVEL", tt.envLevel)
 		var buf bytes.Buffer
-		logger := newZapLoggerWithWriter(&buf)
+		logger := NewZapTestLogger(&buf)
 		logger.Trace("trace msg")
 		logger.Debug("debug msg")
 		logger.Info("info msg")
@@ -263,7 +263,7 @@ func TestZapLoggerTrace(t *testing.T) {
 
 func TestZapLoggerLevelNone(t *testing.T) {
 	var buf bytes.Buffer
-	logger := newZapLoggerWithWriter(&buf, WithLevel(LevelNone))
+	logger := NewZapTestLogger(&buf, WithLevel(LevelNone))
 	logger.Trace("trace")
 	logger.Debug("debug")
 	logger.Info("info")
@@ -315,7 +315,7 @@ func TestZapLoggerWithContextEmpty(t *testing.T) {
 
 func TestZapLoggerWithContextNoCorrelation(t *testing.T) {
 	var buf bytes.Buffer
-	logger := newZapLoggerWithWriter(&buf, WithLevel(LevelInfo))
+	logger := NewZapTestLogger(&buf, WithLevel(LevelInfo), WithGCPTraceCorrelation(false))
 
 	sc := trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    trace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
@@ -330,7 +330,7 @@ func TestZapLoggerWithContextNoCorrelation(t *testing.T) {
 
 func TestZapLoggerWithContextOTEL(t *testing.T) {
 	var buf bytes.Buffer
-	logger := newZapLoggerWithWriter(&buf, WithLevel(LevelInfo), WithGCPTraceCorrelation())
+	logger := NewZapTestLogger(&buf, WithLevel(LevelInfo), WithGCPTraceCorrelation(true))
 
 	sc := trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    trace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
@@ -362,7 +362,7 @@ func TestZapLoggerWithLevel(t *testing.T) {
 
 func TestZapLoggerWithFields(t *testing.T) {
 	var buf bytes.Buffer
-	logger := newZapLoggerWithWriter(&buf, WithLevel(LevelInfo), WithFields(map[string]interface{}{
+	logger := NewZapTestLogger(&buf, WithLevel(LevelInfo), WithFields(map[string]interface{}{
 		"service": "test-svc",
 		"version": "1.0",
 	}))
@@ -376,16 +376,16 @@ func TestZapLoggerWithFields(t *testing.T) {
 
 func TestZapLoggerWithGCPTraceCorrelation(t *testing.T) {
 	var buf bytes.Buffer
-	logger := newZapLoggerWithWriter(&buf, WithLevel(LevelInfo), WithGCPTraceCorrelation())
+	logger := NewZapTestLogger(&buf, WithLevel(LevelInfo), WithGCPTraceCorrelation(true))
 	assert.True(t, logger.gcpTraceCorrelation, "option should set gcpTraceCorrelation flag")
 }
 
 func TestZapLoggerCombinedOptions(t *testing.T) {
 	var buf bytes.Buffer
-	logger := newZapLoggerWithWriter(&buf,
+	logger := NewZapTestLogger(&buf,
 		WithLevel(LevelDebug),
 		WithFields(map[string]interface{}{"env": "test"}),
-		WithGCPTraceCorrelation(),
+		WithGCPTraceCorrelation(true),
 	)
 
 	assert.True(t, logger.gcpTraceCorrelation)
@@ -409,8 +409,8 @@ func TestMuxLoggerFlush(t *testing.T) {
 
 func TestMuxLoggerWithContext(t *testing.T) {
 	var buf1, buf2 bytes.Buffer
-	l1 := newZapLoggerWithWriter(&buf1, WithLevel(LevelInfo), WithGCPTraceCorrelation())
-	l2 := newZapLoggerWithWriter(&buf2, WithLevel(LevelInfo), WithGCPTraceCorrelation())
+	l1 := NewZapTestLogger(&buf1, WithLevel(LevelInfo), WithGCPTraceCorrelation(true))
+	l2 := NewZapTestLogger(&buf2, WithLevel(LevelInfo), WithGCPTraceCorrelation(true))
 	mux := NewMultiLogger(l1, l2)
 
 	sc := trace.NewSpanContext(trace.SpanContextConfig{

--- a/logger/zap_test.go
+++ b/logger/zap_test.go
@@ -1,0 +1,431 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// zapLogEntry represents a parsed JSON log line from the zap logger.
+type zapLogEntry struct {
+	Ts      float64 `json:"ts"`
+	Level   string  `json:"level"`
+	Message string  `json:"msg"`
+	Logger  string  `json:"logger"`
+}
+
+func newTestZapLogger(level LogLevel) (*zapLogger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	logger := newZapLoggerWithWriter(&buf, WithLevel(level))
+	return logger, &buf
+}
+
+func parseZapLines(t *testing.T, buf *bytes.Buffer) []zapLogEntry {
+	t.Helper()
+	var entries []zapLogEntry
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry zapLogEntry
+		require.NoError(t, json.Unmarshal([]byte(line), &entry), "failed to parse JSON line: %s", line)
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func parseRawJSON(t *testing.T, buf *bytes.Buffer) map[string]interface{} {
+	t.Helper()
+	var raw map[string]interface{}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 1)
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &raw))
+	return raw
+}
+
+func levels(entries []zapLogEntry) []string {
+	var result []string
+	for _, e := range entries {
+		result = append(result, e.Level)
+	}
+	return result
+}
+
+func TestZapLogger(t *testing.T) {
+	tests := []struct {
+		level            LogLevel
+		shouldContain    []string
+		shouldNotContain []string
+	}{
+		{
+			level:            LevelTrace,
+			shouldContain:    []string{"trace", "debug", "info", "warn", "error"},
+			shouldNotContain: []string{},
+		},
+		{
+			level:            LevelDebug,
+			shouldContain:    []string{"debug", "info", "warn", "error"},
+			shouldNotContain: []string{"trace"},
+		},
+		{
+			level:            LevelInfo,
+			shouldContain:    []string{"info", "warn", "error"},
+			shouldNotContain: []string{"trace", "debug"},
+		},
+		{
+			level:            LevelWarn,
+			shouldContain:    []string{"warn", "error"},
+			shouldNotContain: []string{"trace", "debug", "info"},
+		},
+		{
+			level:            LevelError,
+			shouldContain:    []string{"error"},
+			shouldNotContain: []string{"trace", "debug", "info", "warn"},
+		},
+	}
+
+	for _, tt := range tests {
+		logger, buf := newTestZapLogger(tt.level)
+		logger.Trace("trace msg")
+		logger.Debug("debug msg")
+		logger.Info("info msg")
+		logger.Warn("warn msg")
+		logger.Error("error msg")
+		_ = logger.sugar.Sync()
+
+		entries := parseZapLines(t, buf)
+		sev := levels(entries)
+		for _, s := range tt.shouldContain {
+			assert.Contains(t, sev, s, "level %v should contain %s", tt.level, s)
+		}
+		for _, s := range tt.shouldNotContain {
+			assert.NotContains(t, sev, s, "level %v should not contain %s", tt.level, s)
+		}
+	}
+}
+
+func TestZapLoggerWithEnvLevel(t *testing.T) {
+	tests := []struct {
+		envLevel         string
+		shouldContain    []string
+		shouldNotContain []string
+	}{
+		{
+			envLevel:         "trace",
+			shouldContain:    []string{"trace", "debug", "info", "warn", "error"},
+			shouldNotContain: []string{},
+		},
+		{
+			envLevel:         "debug",
+			shouldContain:    []string{"debug", "info", "warn", "error"},
+			shouldNotContain: []string{"trace"},
+		},
+		{
+			envLevel:         "info",
+			shouldContain:    []string{"info", "warn", "error"},
+			shouldNotContain: []string{"trace", "debug"},
+		},
+		{
+			envLevel:         "WARN",
+			shouldContain:    []string{"warn", "error"},
+			shouldNotContain: []string{"trace", "debug", "info"},
+		},
+		{
+			envLevel:         "error",
+			shouldContain:    []string{"error"},
+			shouldNotContain: []string{"trace", "debug", "info", "warn"},
+		},
+	}
+
+	for _, tt := range tests {
+		os.Setenv("SM_LOG_LEVEL", tt.envLevel)
+		var buf bytes.Buffer
+		logger := newZapLoggerWithWriter(&buf)
+		logger.Trace("trace msg")
+		logger.Debug("debug msg")
+		logger.Info("info msg")
+		logger.Warn("warn msg")
+		logger.Error("error msg")
+		_ = logger.sugar.Sync()
+		os.Unsetenv("SM_LOG_LEVEL")
+
+		entries := parseZapLines(t, &buf)
+		sev := levels(entries)
+		for _, s := range tt.shouldContain {
+			assert.Contains(t, sev, s, "env %s should contain %s", tt.envLevel, s)
+		}
+		for _, s := range tt.shouldNotContain {
+			assert.NotContains(t, sev, s, "env %s should not contain %s", tt.envLevel, s)
+		}
+	}
+}
+
+func TestZapLoggerWith(t *testing.T) {
+	logger, buf := newTestZapLogger(LevelInfo)
+	derived := logger.With(map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+	})
+	derived.Info("with metadata")
+	_ = derived.(*zapLogger).sugar.Sync()
+
+	raw := parseRawJSON(t, buf)
+	assert.Equal(t, "with metadata", raw["msg"])
+	// Fields are flat top-level, not nested under "metadata"
+	assert.Equal(t, "value1", raw["key1"])
+	assert.Equal(t, "value2", raw["key2"])
+}
+
+func TestZapLoggerWithAdditive(t *testing.T) {
+	logger, buf := newTestZapLogger(LevelInfo)
+	parent := logger.With(map[string]interface{}{"key1": "value1"})
+	child := parent.With(map[string]interface{}{"key2": "value2"})
+	child.Info("additive")
+	_ = child.(*zapLogger).sugar.Sync()
+
+	raw := parseRawJSON(t, buf)
+	assert.Equal(t, "value1", raw["key1"])
+	assert.Equal(t, "value2", raw["key2"])
+}
+
+func TestZapLoggerWithNil(t *testing.T) {
+	logger, buf := newTestZapLogger(LevelInfo)
+	// Must not panic, returns same logger
+	derived := logger.With(nil)
+	derived.Info("after nil with")
+	_ = derived.(*zapLogger).sugar.Sync()
+
+	entries := parseZapLines(t, buf)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "after nil with", entries[0].Message)
+}
+
+func TestZapLoggerWithPrefix(t *testing.T) {
+	logger, buf := newTestZapLogger(LevelInfo)
+
+	// WithPrefix uses zap's Named() — adds a "logger" field
+	p1 := logger.WithPrefix("[myservice]")
+	p1.Info("prefix test")
+	_ = p1.(*zapLogger).sugar.Sync()
+
+	raw := parseRawJSON(t, buf)
+	assert.Equal(t, "[myservice]", raw["logger"])
+
+	// Chained prefix appends with dot separator (zap Named behavior)
+	buf.Reset()
+	p2 := p1.WithPrefix("[subsystem]")
+	p2.Info("chained prefix")
+	_ = p2.(*zapLogger).sugar.Sync()
+
+	raw = parseRawJSON(t, buf)
+	assert.Equal(t, "[myservice].[subsystem]", raw["logger"])
+}
+
+func TestZapLoggerPrintfFormatting(t *testing.T) {
+	logger, buf := newTestZapLogger(LevelTrace)
+	logger.Info("hello %s %d", "world", 42)
+	_ = logger.sugar.Sync()
+
+	entries := parseZapLines(t, buf)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "hello world 42", entries[0].Message)
+}
+
+func TestZapLoggerTrace(t *testing.T) {
+	// At Trace level, both Trace and Debug should appear with distinct severities
+	logger, buf := newTestZapLogger(LevelTrace)
+	logger.Trace("trace msg")
+	logger.Debug("debug msg")
+	_ = logger.sugar.Sync()
+
+	entries := parseZapLines(t, buf)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "trace", entries[0].Level)
+	assert.Equal(t, "debug", entries[1].Level)
+
+	// At Debug level, Trace should be suppressed
+	logger2, buf2 := newTestZapLogger(LevelDebug)
+	logger2.Trace("trace msg")
+	logger2.Debug("debug msg")
+	_ = logger2.sugar.Sync()
+
+	entries2 := parseZapLines(t, buf2)
+	require.Len(t, entries2, 1)
+	assert.Equal(t, "debug", entries2[0].Level)
+}
+
+func TestZapLoggerLevelNone(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newZapLoggerWithWriter(&buf, WithLevel(LevelNone))
+	logger.Trace("trace")
+	logger.Debug("debug")
+	logger.Info("info")
+	logger.Warn("warn")
+	logger.Error("error")
+	_ = logger.sugar.Sync()
+
+	assert.Empty(t, buf.String(), "LevelNone should produce zero output")
+}
+
+func TestZapLoggerFieldNames(t *testing.T) {
+	logger, buf := newTestZapLogger(LevelInfo)
+	logger.Info("field names")
+	_ = logger.sugar.Sync()
+
+	raw := parseRawJSON(t, buf)
+	assert.Contains(t, raw, "ts")
+	assert.Contains(t, raw, "level")
+	assert.Contains(t, raw, "msg")
+}
+
+func TestZapLoggerWarnLevel(t *testing.T) {
+	logger, buf := newTestZapLogger(LevelWarn)
+	logger.Warn("warning test")
+	_ = logger.sugar.Sync()
+
+	entries := parseZapLines(t, buf)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "warn", entries[0].Level)
+}
+
+func TestZapLoggerFlush(t *testing.T) {
+	logger, _ := newTestZapLogger(LevelInfo)
+	err := logger.Flush()
+	assert.NoError(t, err)
+}
+
+func TestZapLoggerWithContextNil(t *testing.T) {
+	logger, _ := newTestZapLogger(LevelInfo)
+	result := logger.WithContext(nil)
+	assert.Equal(t, logger, result, "WithContext(nil) should return self")
+}
+
+func TestZapLoggerWithContextEmpty(t *testing.T) {
+	logger, _ := newTestZapLogger(LevelInfo)
+	result := logger.WithContext(context.Background())
+	assert.Equal(t, logger, result, "WithContext with empty context should return self")
+}
+
+func TestZapLoggerWithContextNoCorrelation(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newZapLoggerWithWriter(&buf, WithLevel(LevelInfo))
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		SpanID:     trace.SpanID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	result := logger.WithContext(ctx)
+	assert.Equal(t, logger, result, "without GCP correlation, WithContext should return self")
+}
+
+func TestZapLoggerWithContextOTEL(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newZapLoggerWithWriter(&buf, WithLevel(LevelInfo), WithGCPTraceCorrelation())
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		SpanID:     trace.SpanID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	derived := logger.WithContext(ctx)
+	derived.Info("otel test")
+	_ = derived.(*zapLogger).sugar.Sync()
+
+	raw := parseRawJSON(t, &buf)
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", raw["logging.googleapis.com/trace"])
+	assert.Equal(t, "0102030405060708", raw["logging.googleapis.com/spanId"])
+	assert.Equal(t, true, raw["logging.googleapis.com/trace_sampled"])
+}
+
+func TestZapLoggerWithLevel(t *testing.T) {
+	logger, buf := newTestZapLogger(LevelWarn)
+	logger.Info("should not appear")
+	logger.Warn("should appear")
+	_ = logger.sugar.Sync()
+
+	entries := parseZapLines(t, buf)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "warn", entries[0].Level)
+}
+
+func TestZapLoggerWithFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newZapLoggerWithWriter(&buf, WithLevel(LevelInfo), WithFields(map[string]interface{}{
+		"service": "test-svc",
+		"version": "1.0",
+	}))
+	logger.Info("fields test")
+	_ = logger.sugar.Sync()
+
+	raw := parseRawJSON(t, &buf)
+	assert.Equal(t, "test-svc", raw["service"])
+	assert.Equal(t, "1.0", raw["version"])
+}
+
+func TestZapLoggerWithGCPTraceCorrelation(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newZapLoggerWithWriter(&buf, WithLevel(LevelInfo), WithGCPTraceCorrelation())
+	assert.True(t, logger.gcpTraceCorrelation, "option should set gcpTraceCorrelation flag")
+}
+
+func TestZapLoggerCombinedOptions(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newZapLoggerWithWriter(&buf,
+		WithLevel(LevelDebug),
+		WithFields(map[string]interface{}{"env": "test"}),
+		WithGCPTraceCorrelation(),
+	)
+
+	assert.True(t, logger.gcpTraceCorrelation)
+
+	logger.Debug("combined test")
+	_ = logger.sugar.Sync()
+
+	raw := parseRawJSON(t, &buf)
+	assert.Equal(t, "test", raw["env"])
+	assert.Equal(t, "debug", raw["level"])
+}
+
+func TestMuxLoggerFlush(t *testing.T) {
+	l1, _ := newTestZapLogger(LevelInfo)
+	l2, _ := newTestZapLogger(LevelInfo)
+	mux := NewMultiLogger(l1, l2)
+
+	err := mux.Flush()
+	assert.NoError(t, err)
+}
+
+func TestMuxLoggerWithContext(t *testing.T) {
+	var buf1, buf2 bytes.Buffer
+	l1 := newZapLoggerWithWriter(&buf1, WithLevel(LevelInfo), WithGCPTraceCorrelation())
+	l2 := newZapLoggerWithWriter(&buf2, WithLevel(LevelInfo), WithGCPTraceCorrelation())
+	mux := NewMultiLogger(l1, l2)
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		SpanID:     trace.SpanID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	derived := mux.WithContext(ctx)
+	derived.Info("mux context test")
+
+	for i, buf := range []*bytes.Buffer{&buf1, &buf2} {
+		entries := parseZapLines(t, buf)
+		require.Len(t, entries, 1, "logger %d should have 1 entry", i)
+		assert.Equal(t, "mux context test", entries[0].Message)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands the `Logger` interface (new methods and log levels), which is a potentially breaking API change for downstream consumers. Adds a new zap-based implementation and trace-context enrichment that could subtly change default logging behavior (notably default level for zap).
> 
> **Overview**
> **Adds a new zap-backed logger** (`NewZapLogger`/`NewZapGCloudLogger`) with structured JSON output, configurable options (`WithLevel`, initial `WithFields`, `WithGCPTraceCorrelation`), and `Flush()` support.
> 
> **Extends the logging API** by adding `WithFields`, `WithContext`, `Flush`, and new log levels (`panic`, `fatal`), plus a `KV(...)` helper and `ParseLogLevel`; existing console/JSON/test/multi loggers are updated to implement the new interface and `MultiLogger` now fans out `WithContext` and aggregates `Flush` errors.
> 
> Introduces `logger` context helpers (`ToContext`/`FromContext`) with a default fallback logger (zap), adds documentation, tests for zap behavior/levels/trace correlation, and updates module deps to include `go.uber.org/zap` and `go.opentelemetry.io/otel/trace` (plus indirects).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc4970cb1f7653b4a5e383b15cba903b51a53793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->